### PR TITLE
Fix extreme long execution time in evaluation.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Run the following command:
 ```bash
 python eval/evaluation.py --plug_value --input Your_model_pred_file
 ```
-You can find the results of our latest review [here](doc/eval_llm_result.md)
+You can find the results of our latest review [here](docs/eval_llm_result.md)
 
 
 ## 4. RoadMap 

--- a/README.zh.md
+++ b/README.zh.md
@@ -199,7 +199,7 @@ sh scripts/qlora/get_predict_qlora.sh
 ```bash
 python eval/evaluation.py --plug_value --input  Your_model_pred_file
 ```
-你可以在[这里](doc/eval_llm_result.md)找到我们最新的审查结果。
+你可以在[这里](docs/eval_llm_result.md)找到我们最新的审查结果。
 ## 四、发展路线
 
 整个过程我们会分为三个阶段：

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ datasets
 deepspeed>=0.10.0
 sqlparse
 nltk
+func-timeout==4.3.5


### PR DESCRIPTION
Some predictions may cause extremely long execution time lasting longer than 5 or 6 hours. Sometimes the evaluation script just gets stuck and fails to evaluate the whole dev dataset even after several days.

I tried to fix this issue by adding a timeout of 30 seconds in the execution phase of the evaluation.py. It returns None if the function is timeout. I suppose that this will fix the problem.