### PR TITLE
HUB #226: baseline bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
     <td>0.352</td>
     <td>0.201</td>
     <td>0.066</td>
-    <td>335</td>
+    <td>0.335</td>
   </tr>
   <tr>
     <td>Baichuan2-7B-Chat</td>

--- a/README.zh.md
+++ b/README.zh.md
@@ -157,7 +157,7 @@
     <td>0.352</td>
     <td>0.201</td>
     <td>0.066</td>
-    <td>335</td>
+    <td>0.335</td>
   </tr>
   <tr>
     <td>Baichuan2-7B-Chat</td>

--- a/docs/eval_llm_result.md
+++ b/docs/eval_llm_result.md
@@ -156,7 +156,7 @@ the model
 <td>0.352</td>
 <td>0.201</td>
 <td>0.066</td>
-<td>335</td>
+<td>0.335</td>
 </tr>
 <tr>
 <td></td>


### PR DESCRIPTION
>>> # 定义各难度级别的数量和正确率
>>> counts = {'easy': 248, 'medium': 446, 'hard': 174, 'extra': 166}
>>> accuracies = {'easy': 0.577, 'medium': 0.352, 'hard': 0.201, 'extra': 0.066}
>>> 
>>> # 计算总题目数量和总正确数量
>>> total_count = sum(counts.values())
>>> total_correct = sum(count * accuracy for count, accuracy in zip(counts.values(), accuracies.values()))
>>> 
>>> # 计算总正确率
>>> overall_accuracy = total_correct / total_count
>>> 
>>> # 输出结果
>>> print(f"总正确率为: {overall_accuracy:.3f}")
总正确率为: 0.335
>>> 