### PR TITLE
fix lower case create statement

### DIFF
--- a/dbgpt_hub/data_process/sql_data_process.py
+++ b/dbgpt_hub/data_process/sql_data_process.py
@@ -159,7 +159,7 @@ class ProcessSqlData:
                         with open(schema_file_path, "r") as file:
                             schema_content = file.read()
                         create_statements = re.findall(
-                            r"CREATE\s.*?;", schema_content, re.DOTALL
+                            r"CREATE\s.*?;", schema_content, re.DOTALL|re.IGNORECASE
                         )
                         input = {
                             "db_id": data[db_id_name],


### PR DESCRIPTION
The current `dbgpt_hub/data_process/sql_data_process.py` script does not consider there actually exists lowercase create statements in the spider dataset. For example, `activity_1/schema.sql` contains `create table Activity ...` which is not captured by the `r"CREATE\s.*?;"` pattern in [line of code here](https://github.com/eosphoros-ai/DB-GPT-Hub/blob/f7187bf2ce514fd4abe6b4b19b18f46088dbcacf/dbgpt_hub/data_process/sql_data_process.py#L162). The consequence is that some samples in the `example_text2sql_dev.json` have blank Instruction field when enable the `--code_representation`:

```
{
    "db_id": "pets_1",
    "instruction": "I want you to act as a SQL terminal in front of an example database, you need only to return the sql command to me.Below is an instruction that describes a task,      Write a response that appropriately completes the request.\n\"\n##Instruction:\n[]\n",
    "input": "###Input:\nHow many dog pets are raised by female students?\n\n###Response:",
    "output": "SELECT count(*) FROM student AS T1 JOIN has_pet AS T2 ON T1.stuid  =  T2.stuid JOIN pets AS T3 ON T2.petid  =  T3.petid WHERE T1.sex  =  'F' AND T3.pettype  =  'dog'",
"history": []
}
```


This pull request makes the specific pattern case-insensitive to fix this problem. 

```
create_statements = re.findall(
    r"CREATE\s.*?;", schema_content, re.DOTALL**|re.IGNORECASE**
)
```
